### PR TITLE
Added method to convert NSData to NSString for iOS13 compatibility

### DIFF
--- a/iOS/CryptLib.h
+++ b/iOS/CryptLib.h
@@ -38,5 +38,6 @@
 -  (NSString *) decryptCipherText:(NSString *)cipherText key:(NSString *)key iv:(NSString *)iv;
 -  (NSString *) encryptPlainTextRandomIVWithPlainText:(NSString *)plainText key:(NSString *)key;
 -  (NSString *) decryptCipherTextRandomIVWithCipherText:(NSString *)cipherText key:(NSString *)key;
+-  (NSString *)hexadecimalStringFromData:(NSData *)data;
 
 @end

--- a/iOS/CryptLib.m
+++ b/iOS/CryptLib.m
@@ -208,7 +208,7 @@
     uint8_t digest[CC_SHA256_DIGEST_LENGTH]={0};
     CC_SHA256(keyData.bytes, (CC_LONG)keyData.length, digest);
     NSData *out=[NSData dataWithBytes:digest length:CC_SHA256_DIGEST_LENGTH];
-    NSString *hash=[out description];
+    NSString *hash=[self hexadecimalStringFromData:out];
     hash = [hash stringByReplacingOccurrencesOfString:@" " withString:@""];
     hash = [hash stringByReplacingOccurrencesOfString:@"<" withString:@""];
     hash = [hash stringByReplacingOccurrencesOfString:@">" withString:@""];
@@ -221,6 +221,20 @@
     {
         return [hash substringToIndex:length];
     }
+}
+
+- (NSString *)hexadecimalStringFromData:(NSData *)data{
+    NSUInteger dataLength = data.length;
+    if (dataLength == 0) {
+        return nil;
+    }
+
+    const unsigned char *dataBuffer = data.bytes;
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    return [hexString copy];
 }
 
 @end


### PR DESCRIPTION
The iOS13 issue is caused by incorrectly using the [NSData description] method to convert the identifier to a String. A simple solution is to format the bytes into the desired format.